### PR TITLE
Remove '2' and 'Z' from nolookalikes

### DIFF
--- a/nolookalikes.js
+++ b/nolookalikes.js
@@ -1,1 +1,1 @@
-module.exports = '2346789ABCDEFGHJKLMNPQRTUVWXYZabcdefghijkmnpqrtwxyz';
+module.exports = '346789ABCDEFGHJKLMNPQRTUVWXYabcdefghijkmnpqrtwxyz';


### PR DESCRIPTION
They might look similar, especially when using monospace fonts.