### PR TITLE
Add hexadecimal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ Numbers from 0 to 9
 import { numbers } from 'nanoid-dictionary';
 ```
 
+### `hexadecimalLowercase`
+
+Lowercase English hexadecimal lowercase characters: `0123456789abcdef`
+
+```javascript
+import { hexadecimalLowercase } from 'nanoid-dictionary';
+```
+
+### `hexadecimalUppercase`
+
+Lowercase English hexadecimal uppercase characters: `0123456789ABCDEF`
+
+```javascript
+import { hexadecimalUppercase } from 'nanoid-dictionary';
+```
+
 ### `lowercase`
 
 Lowercase English letters: `abcdefghijklmnopqrstuvwxyz`

--- a/src/hexadecimal-lowercase.js
+++ b/src/hexadecimal-lowercase.js
@@ -1,0 +1,3 @@
+import { numbers } from './numbers';
+
+export const hecadecimalLowercase = numbers + 'abcdef';

--- a/src/hexadecimal-uppercase.js
+++ b/src/hexadecimal-uppercase.js
@@ -1,0 +1,3 @@
+import { numbers } from './numbers';
+
+export const hecadecimalUppercase = numbers + 'ABCDEF';

--- a/src/nanoid-dictionary.js
+++ b/src/nanoid-dictionary.js
@@ -1,4 +1,6 @@
 export { alphanumeric } from './alphanumeric';
+export { hexadecimalLowercase } from './hexadecimal-lowercase';
+export { hexadecimalUppercase } from './hexadecimal-uppercase';
 export { lowercase } from './lowercase';
 export { nolookalikes } from './nolookalikes';
 export { nolookalikesSafe } from './nolookalikes-safe';


### PR DESCRIPTION
This PR adds support for the `hexadecimalLowercase` and `hexadecimalUppercase` dictionaries.